### PR TITLE
Fixed example code syntax issue in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $provider = new \CloudManaged\OAuth2\Client\Provider\FreeAgent([
     'sandbox' => "TRUE_OR_FALSE",
     'clientId' => "YOUR_CLIENT_ID",
     'clientSecret' => "YOUR_CLIENT_SECRET",
-    'responseType' => "JSON_OR_STRING"
+    'responseType' => "JSON_OR_STRING",
     'redirectUri' => "http://your-redirect-uri"
 ]);
 


### PR DESCRIPTION
Missing a comma in the `$provider` setup